### PR TITLE
fix quoting

### DIFF
--- a/lib/atos.rb
+++ b/lib/atos.rb
@@ -29,7 +29,7 @@ class Atos
          
     args = ''
     datas.each do |key, value|
-      args << "#{key.to_s}=\"#{value}\" "
+      args << "'#{key.to_s}=#{value}'"
     end        
     
     response_array = ExceptionHandler.on_launch(`#{self.request_path} #{args}`)


### PR DESCRIPTION
Je préfère les simple quotes pour échapper les paramètres. (et SIPS aussi, il crashe sur les double quotes et ma requête.)
